### PR TITLE
Check for implementation of Jason.Encoder for structs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -11,6 +11,7 @@ defmodule Medea.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       aliases: aliases(),
+      consolidate_protocols: Mix.env() != :test,
       preferred_cli_env: [
         "test.ci": :test
       ],

--- a/test/medea/translator_test.exs
+++ b/test/medea/translator_test.exs
@@ -5,6 +5,16 @@ defmodule Medea.TranslatorTest do
 
   alias Medea.Translator
 
+  require Protocol
+
+  defmodule Struct do
+    @moduledoc false
+
+    defstruct id: 1,
+              private: %{data: :hidden},
+              public: %{data: :visible}
+  end
+
   describe "translate/4" do
     property "all terms are safely encoded to iodata" do
       check all message <- message() do
@@ -14,12 +24,33 @@ defmodule Medea.TranslatorTest do
       end
     end
 
+    test "custom implementations of Jason.Encoder are respected" do
+      # Private data is exposed
+      assert {:ok, iodata} = Translator.translate(:info, :info, :report, {:logger, %Struct{}})
+
+      assert ~s({"id":1,"private":{"data":"hidden"},"public":{"data":"visible"}}) ==
+               IO.chardata_to_string(iodata)
+
+      # Private data is redacted
+      Protocol.derive(Jason.Encoder, Struct, except: [:private])
+
+      assert {:ok, iodata} = Translator.translate(:info, :info, :report, {:logger, %Struct{}})
+      assert ~s({"id":1,"public":{"data":"visible"}}) == IO.chardata_to_string(iodata)
+    end
+
     test "all non-logger formats or reports are ignored" do
       assert :none = Translator.translate(:info, :info, :report, {:not, :from, :logger})
     end
   end
 
   defp message do
+    one_of([
+      random(),
+      struct()
+    ])
+  end
+
+  defp random do
     one_of([
       atom(:alphanumeric),
       binary(),
@@ -33,4 +64,6 @@ defmodule Medea.TranslatorTest do
   defp key, do: one_of([atom(:alphanumeric), string(:ascii)])
 
   defp val, do: one_of([atom(:alphanumeric), map_of(key(), key())])
+
+  defp struct, do: map(random(), &%Struct{private: &1, public: &1})
 end


### PR DESCRIPTION
If a struct has a custom implementation of `Jason.Encoder` we'll clean the internals but put everything back where we found it so the custom implementation could redact fields, for example.