### PR TITLE
Inspect non-atom/string keys

### DIFF
--- a/lib/medea/utils.ex
+++ b/lib/medea/utils.ex
@@ -19,7 +19,7 @@ defmodule Medea.Utils do
   end
 
   def clean(map) when is_map(map) do
-    for {key, val} <- map, into: %{}, do: {clean(key), clean(val)}
+    for {key, val} <- map, into: %{}, do: {clean_key(key), clean(val)}
   end
 
   def clean(list) when is_list(list) do
@@ -42,6 +42,9 @@ defmodule Medea.Utils do
   def clean(term) when is_pid(term) or is_reference(term), do: inspect(term)
   def clean(term) when is_port(term) or is_function(term), do: inspect(term)
   def clean(term), do: term
+
+  defp clean_key(key) when is_atom(key) or is_binary(key), do: key
+  defp clean_key(key), do: inspect(key)
 
   defp clean_struct(struct) do
     struct

--- a/test/medea/translator_test.exs
+++ b/test/medea/translator_test.exs
@@ -57,7 +57,8 @@ defmodule Medea.TranslatorTest do
       tuple({key(), val()}),
       map_of(key(), val()),
       keyword_of(val()),
-      list_of(one_of([tuple({key(), val()}), atom(:alphanumeric)]))
+      list_of(one_of([tuple({key(), val()}), atom(:alphanumeric)])),
+      map_of(list_of(atom(:alphanumeric)), val())
     ])
   end
 


### PR DESCRIPTION
Instead of exploding on map keys in Jason if they were a list like `[:foo, "bar"]` or a map, etc., we'll allow strings or atoms as before, but `inspect` otherwise.