### PR TITLE
Add escape-hatch for custom key value formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,60 @@ And attach:
 )
 ```
 
+## Custom logger formatting
+
+If you need to format certain values in the log set by other libraries,
+for example, `:otel_span_id` and `:otel_trace_id`, then you can configure
+medea to send certain keypaths to your own implementation.
+
+For example:
+
+Before:
+
+```json
+{
+  "level":"info",
+  "message":{"foo":"bar"},
+  "metadata":{
+    "otel_span_id":[0,1,2,3,4],
+    "otel_trace_id":[3,4,5]
+  },
+  "time":"2022-10-11T15:07:33.000"
+}
+```
+
+```elixir
+config :medea,
+  formatters: %{
+    [:metadata, :otel_span_id] => {MyApp.Logs, :format, []},
+    [:metadata, :otel_trace_id] => {MyApp.Logs, :format, []}
+  }
+```
+
+```elixir
+defmodule MyApp.Logs do
+  def format(_keypath, charlist) when is_list(charlist) do
+    to_string(charlist)
+  end
+
+  def format(_keypath, value), do: value
+end
+```
+
+After:
+
+```json
+{
+  "level":"info",
+  "message":{"foo":"bar"},
+  "metadata":{
+    "otel_span_id":"abc123",
+    "otel_trace_id":"def456"
+  },
+  "time":"2022-10-11T15:07:33.000"
+}
+```
+
 ## Custom `Jason.Encoder` Implementations
 
 Structs that implement [Jason.Encoder](https://hexdocs.pm/jason/Jason.Encoder.html) will use that protocol.

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,5 @@
 import Config
 
 config :logger, :default_formatter, format: {Medea.Formatter, :format}
+
+if Mix.env() == :test, do: import_config("test.exs")

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,7 @@
+import Config
+
+config :medea,
+  formatters: %{
+    [:metadata, :otel_span_id] => {Medea.FormatterTest.EscapeHatch, :format, []},
+    [:metadata, :otel_trace_id] => {Medea.FormatterTest.EscapeHatch, :format, []}
+  }

--- a/lib/medea/formatter.ex
+++ b/lib/medea/formatter.ex
@@ -36,9 +36,7 @@ defmodule Medea.Formatter do
   defp to_val(:message, message), do: Jason.encode_to_iodata!(message)
 
   defp to_val(:metadata, metadata) do
-    metadata
-    |> Utils.clean()
-    |> Jason.encode_to_iodata!()
+    Jason.encode_to_iodata!(Utils.clean([:metadata], metadata))
   end
 
   defp to_val(:time, {date, {h, m, s, ms}}) do

--- a/lib/medea/translator.ex
+++ b/lib/medea/translator.ex
@@ -10,8 +10,8 @@ defmodule Medea.Translator do
   @impl Logger.Translator
   def translate(_min, _level, :report, {:logger, message}) do
     encoded =
-      message
-      |> Utils.clean()
+      []
+      |> Utils.clean(message)
       |> Jason.encode_to_iodata!()
 
     {:ok, encoded}

--- a/lib/medea/utils.ex
+++ b/lib/medea/utils.ex
@@ -3,51 +3,52 @@ defmodule Medea.Utils do
 
   alias Jason.Encoder
 
-  def clean(%Date{} = date), do: date
-  def clean(%DateTime{} = datetime), do: datetime
-  def clean(%NaiveDateTime{} = naive), do: naive
-  def clean(%Time{} = time), do: time
+  for {keypath, {m, f, a}} <- Application.compile_env(:medea, :formatters, %{}) do
+    def clean(unquote(keypath), value) do
+      apply(unquote(m), unquote(f), [unquote(keypath), value] ++ unquote(a))
+    end
+  end
+
+  def clean(_keypath, %Date{} = date), do: date
+  def clean(_keypath, %DateTime{} = datetime), do: datetime
+  def clean(_keypath, %NaiveDateTime{} = naive), do: naive
+  def clean(_keypath, %Time{} = time), do: time
 
   # Structs should implement Jason.Encoder
-  def clean(%module{} = struct) do
+  def clean(keypath, %module{} = struct) do
     if Encoder.Any == Encoder.impl_for(struct) or
          module in Application.get_env(:medea, :except, []) do
-      clean_struct(struct)
+      clean_struct(keypath, struct)
     else
-      struct!(struct, clean_struct(struct))
+      struct!(struct, clean_struct(keypath, struct))
     end
   end
 
-  def clean(map) when is_map(map) do
-    for {key, val} <- map, into: %{}, do: {clean_key(key), clean(val)}
+  def clean(keypath, map) when is_map(map) do
+    for {key, val} <- map, into: %{} do
+      {clean_key(key), clean(keypath ++ [key], val)}
+    end
   end
 
-  def clean(list) when is_list(list) do
+  def clean(keypath, list) when is_list(list) do
     cond do
-      List.improper?(list) -> list |> convert_to_proper_list([]) |> clean()
-      Keyword.keyword?(list) -> list |> Map.new() |> clean()
-      true -> Enum.map(list, &clean/1)
+      List.improper?(list) -> clean(keypath, convert_to_proper_list(list, []))
+      Keyword.keyword?(list) -> clean(keypath, Map.new(list))
+      true -> Enum.map(list, &clean(keypath, &1))
     end
   end
 
-  def clean(tuple) when is_tuple(tuple) do
-    tuple
-    |> Tuple.to_list()
-    |> clean()
+  def clean(keypath, tuple) when is_tuple(tuple) do
+    clean(keypath, Tuple.to_list(tuple))
   end
 
-  def clean(binary) when is_binary(binary), do: Logger.Formatter.prune(binary)
-  def clean(term) when is_pid(term) or is_reference(term), do: inspect(term)
-  def clean(term) when is_port(term) or is_function(term), do: inspect(term)
-  def clean(term), do: term
+  def clean(_keypath, binary) when is_binary(binary), do: Logger.Formatter.prune(binary)
+  def clean(_keypath, term) when is_pid(term) or is_reference(term), do: inspect(term)
+  def clean(_keypath, term) when is_port(term) or is_function(term), do: inspect(term)
+  def clean(_keypath, term), do: term
 
-  defp clean_key(key) when is_atom(key) or is_binary(key), do: key
-  defp clean_key(key), do: inspect(key)
-
-  defp clean_struct(struct) do
-    struct
-    |> Map.from_struct()
-    |> clean()
+  defp clean_struct(key, struct) do
+    clean(key, Map.from_struct(struct))
   end
 
   defp convert_to_proper_list([], acc), do: Enum.reverse(acc)
@@ -59,4 +60,7 @@ defmodule Medea.Utils do
   defp convert_to_proper_list([head | tail], acc) do
     convert_to_proper_list([tail], [head | acc])
   end
+
+  defp clean_key(key) when is_atom(key) or is_binary(key), do: key
+  defp clean_key(key), do: inspect(key)
 end

--- a/test/medea/formatter_test.exs
+++ b/test/medea/formatter_test.exs
@@ -14,6 +14,19 @@ defmodule Medea.FormatterTest do
     |> Jason.decode!()
   end
 
+  defmodule EscapeHatch do
+    @eligible [
+      [:metadata, :otel_span_id],
+      [:metadata, :otel_trace_id]
+    ]
+
+    def format(keypath, value) when keypath in @eligible and is_list(value) do
+      to_string(value)
+    end
+
+    def format(_keypath, value), do: value
+  end
+
   describe "format/4" do
     property "encoding any messages as json iodata" do
       check all level <- level(), time <- datetime(), message <- message() do
@@ -21,6 +34,17 @@ defmodule Medea.FormatterTest do
 
         assert %{"level" => _, "time" => _, "message" => _} = decoded
       end
+    end
+
+    test "configured keys are sent to custom cleaners" do
+      metadata = [otel_span_id: ~c"abc123", otel_trace_id: ~c"def456"]
+
+      assert %{
+               "metadata" => %{
+                 "otel_span_id" => "abc123",
+                 "otel_trace_id" => "def456"
+               }
+             } = format(:info, "boop", @datetime, metadata)
     end
 
     test "formatting log datetimes" do


### PR DESCRIPTION
OpenTelemetry libraries add some metadata to logger, but they add them as charlists (`otel_span_id` and `otel_trace_id`) which ends up as a list of integers in the JSON log. For log correlation with some services (such as Datadog), they need these IDs to be in hex format, which means I need to be able to hook into the log formatting for these particular keys and values and format them.

This adds a compile-config-based escape hatch for formatting values in the logger message.